### PR TITLE
Add partitioned support to Sequence and Table sources

### DIFF
--- a/intake_solr/__init__.py
+++ b/intake_solr/__init__.py
@@ -1,7 +1,4 @@
 from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions
-
-import intake  # Import this first to avoid circular imports during discovery.
-del intake
 from .source import SOLRSequenceSource, SOLRTableSource

--- a/intake_solr/source.py
+++ b/intake_solr/source.py
@@ -108,6 +108,14 @@ class SOLRSequenceSource(base.DataSource):
                         for k, v in d.items()})
         return out
 
+    def _close(self):
+        pass
+
+    def read(self):
+        self._load_metadata()
+        from itertools import chain
+        return chain(*(self._get_partition(index) for index in range(self.npartitions)))
+
     def to_dask(self):
         from dask import delayed
         import dask.bag

--- a/intake_solr/source.py
+++ b/intake_solr/source.py
@@ -162,10 +162,15 @@ class SOLRTableSource(SOLRSequenceSource):
         """Get schema from first 10 hits or cached dataframe"""
         schema = super()._get_schema()
 
-        df = self._get_partition(0)
-        schema["dtype"] = {k: str(v)
-                           for k, v in df.dtypes.to_dict().items()}
-        schema["shape"] = (schema["shape"][0], *df.shape[1:])
+        prev_partition_len = self.partition_len
+        try:
+            self.partition_len = 10
+            df = self._get_partition(0)
+            schema["dtype"] = {k: str(v) for k, v in df.dtypes.to_dict().items()}
+            schema["shape"] = (schema["shape"][0], *df.shape[1:])
+        finally:
+            self.partition_len = prev_partition_len
+
         return schema
 
     def _get_partition(self, index):

--- a/intake_solr/source.py
+++ b/intake_solr/source.py
@@ -1,3 +1,5 @@
+import math
+
 from intake.source import base
 import pandas as pd
 import pysolr
@@ -28,18 +30,24 @@ class SOLRSequenceSource(base.DataSource):
     zoocollection: bool or str
         If using Zookeeper to orchestrate SOLR, this is the name of the
         collection to connect to.
+    partition_len: int or None
+        The desired partition size. [default: 1024]
     """
     container = 'python'
     name = 'solr'
     version = __version__
-    partition_access = False
 
     def __init__(self, query, base_url, core, qargs=None, metadata=None,
-                 auth=None, cert=None, zoocollection=False):
+                 auth=None, cert=None, zoocollection=False,
+                 partition_len=1024):
         self.query = query
         self.qargs = qargs or {}
         self.metadata = metadata or {}
         self._schema = None
+        self.partition_len = partition_len
+
+        if partition_len and partition_len <= 0:
+            raise ValueError(f"partition_len must be None or positive, got {partition_len}")
         if auth == 'kerberos':
             from requests_kerberos import HTTPKerberosAuth, OPTIONAL
             auth = HTTPKerberosAuth(mutual_authentication=OPTIONAL,
@@ -64,24 +72,49 @@ class SOLRSequenceSource(base.DataSource):
         super(SOLRSequenceSource, self).__init__(metadata=metadata)
 
     def _get_schema(self):
-        return base.Schema(datashape=None,
-                           dtype=None,
-                           shape=None,
-                           npartitions=1,
-                           extra_metadata={})
+        """Do a 0 row query and get the number of hits from the response"""
+        qargs = self.qargs.copy()
+        qargs["rows"] = 0
+        start = qargs.get("start", 0)
+        results = self.solr.search(self.query, **qargs)
 
-    def _do_query(self):
+        if self.partition_len is None:
+            npartitions = 1
+        else:
+            npartitions = math.ceil((results.hits - start) / self.partition_len)
+
+        return base.Schema(
+            datashape=None,
+            dtype=None,
+            shape=(results.hits - start,),
+            npartitions=npartitions,
+            extra_metadata={},
+        )
+
+    def _do_query(self, index):
+        qargs = self.qargs.copy()
+        if self.partition_len is not None:
+            qargs["start"] = qargs.get("start", 0) + index * self.partition_len
+            qargs["rows"] = self.partition_len
+        return self.solr.search(self.query, **qargs)
+
+    def _get_partition(self, index):
+        """Downloads all data in query response"""
+        solr_rv = self._do_query(index)
         out = []
-        data = self.solr.search(self.query, **self.qargs).docs
-        for d in data:
+        for d in solr_rv.docs:
             out.append({k: (v[0] if isinstance(v, (tuple, list)) else v)
                         for k, v in d.items()})
         return out
 
-    def _get_partition(self, _):
-        """Downloads all data
-        """
-        return self._do_query()
+    def to_dask(self):
+        from dask import delayed
+        import dask.bag
+
+        npartitions = self.discover()["npartitions"]
+        return dask.bag.from_delayed(
+            [delayed(self.read_partition)(i) for i in range(npartitions)]
+        )
 
 
 class SOLRTableSource(SOLRSequenceSource):
@@ -129,7 +162,7 @@ class SOLRTableSource(SOLRSequenceSource):
         """Downloads all data
         """
         if not hasattr(self, '_dataframe'):
-            df = pd.DataFrame(self._do_query())
+            df = pd.DataFrame(super()._get_partition(_))
             self._dataframe = df
             self._schema = None
             self.discover()

--- a/intake_solr/source.py
+++ b/intake_solr/source.py
@@ -176,6 +176,10 @@ class SOLRTableSource(SOLRSequenceSource):
         columns = self.qargs["fl"] if "fl" in self.qargs else sorted(seq[0].keys())
         return pd.DataFrame(seq, columns=columns)
 
+    def read(self):
+        self._load_metadata()
+        return pd.concat(self._get_partition(index) for index in range(self.npartitions))
+
     def to_dask(self):
         from dask import delayed
         import dask.dataframe

--- a/tests/test_intake_solr.py
+++ b/tests/test_intake_solr.py
@@ -9,7 +9,7 @@ from intake_solr import SOLRSequenceSource, SOLRTableSource
 from .util import start_solr, stop_docker, TEST_CORE
 
 CONNECT = {'host': 'localhost', 'port': 9200}
-TEST_DATA_DIR = 'tests'
+TEST_DATA_DIR = os.path.abspath(os.path.dirname(__file__))
 TEST_DATA = 'sample1.csv'
 df = pd.read_csv(os.path.join(TEST_DATA_DIR, TEST_DATA))
 


### PR DESCRIPTION
This PR tries to add support for Partitioned access to a Solr collection. By default, we define the partition_len to be 1024 records. During metadata lookup we can get a hit on the number of records in the solr collection. The number of partitions becomes `ceil(numRecords/partition_len)`

:scroll: Note:
- Current implementation uses the simple pagination features (start, rows). This is problematic when we do [deep-pagination][deep]. 
- We could implement [cursors][cursor] as an option, as long as the user understands that:
  - There is an additional cost the first time they access partitions out of order;
  - With my current knowledge of DASK, an all-upfront cost when we call `to_dask`;
  - The user provides us with the pre-computed cursors. I suggest creating a SOLRCursorSource to help in create this content.

The problem is that the cursors can only be obtained by iterating one page at a time(can't be paralleized). Fortunately, we only need the document id's and not the entire SOLR response, so the network transfer cost is small.

[cursor]: https://lucene.apache.org/solr/guide/8_6/pagination-of-results.html#fetching-a-large-number-of-sorted-results-cursors
[deep]: https://lucene.apache.org/solr/guide/8_6/pagination-of-results.html#performance-problems-with-deep-paging